### PR TITLE
fix: Add missing RemoveRecipientMentionMiddlewareBuilder to component registration

### DIFF
--- a/src/Microsoft.Bot.Core/CoreBotComponentRegistration.cs
+++ b/src/Microsoft.Bot.Core/CoreBotComponentRegistration.cs
@@ -31,6 +31,8 @@ namespace Microsoft.Bot.Core
                 TelemetryMiddlewareBuilder.Kind);
             yield return new DeclarativeType<TranscriptLoggerMiddlewareBuilder>(
                 TranscriptLoggerMiddlewareBuilder.Kind);
+            yield return new DeclarativeType<RemoveRecipientMentionMiddlewareBuilder>(
+                RemoveRecipientMentionMiddlewareBuilder.Kind);
 
             // Transcript Logger builders
             yield return new DeclarativeType<FileTranscriptLoggerBuilder>(


### PR DESCRIPTION
Fixes #47

## Description
<!-- Please discuss the changes you have worked on. What do the changes do; why is this PR needed? -->
The declarative component registration of RemoveRecipientMentionMiddlewareBuilder is missing and the bot does not start appropriately. This resolves that bug.

## Testing
<!-- If you are adding a new feature to a library, you must include tests for your new code. -->
No new tests