### PR TITLE
refactor: Renamed AddBotCore to AddBotRuntime

### DIFF
--- a/src/Microsoft.Bot.Builder.Runtime.WebHost/Program.cs
+++ b/src/Microsoft.Bot.Builder.Runtime.WebHost/Program.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Bot.Runtime.WebHost
                 IHostEnvironment env = hostingContext.HostingEnvironment;
 
                 // Use Composer bot path adapter
-                builder.AddBotCoreConfiguration(
+                builder.AddBotRuntimeConfiguration(
                     applicationRoot: Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location),
                     isDevelopment: env.IsDevelopment());
 

--- a/src/Microsoft.Bot.Builder.Runtime.WebHost/Startup.cs
+++ b/src/Microsoft.Bot.Builder.Runtime.WebHost/Startup.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Bot.Runtime.WebHost
 
             services.AddSingleton<IConfiguration>(this.Configuration);
 
-            services.AddBotCore(this.Configuration);
+            services.AddBotRuntime(this.Configuration);
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/src/Microsoft.Bot.Builder.Runtime/Extensions/ConfigurationBuilderExtensions.cs
+++ b/src/Microsoft.Bot.Builder.Runtime/Extensions/ConfigurationBuilderExtensions.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Bot.Builder.Runtime.Extensions
         /// <returns>
         /// Supplied <see cref="IConfigurationBuilder"/> instance with additional in-memory configuration provider.
         /// </returns>
-        public static IConfigurationBuilder AddBotCoreConfiguration(
+        public static IConfigurationBuilder AddBotRuntimeConfiguration(
             this IConfigurationBuilder builder,
             string applicationRoot,
             bool isDevelopment = true)

--- a/src/Microsoft.Bot.Builder.Runtime/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Microsoft.Bot.Builder.Runtime/Extensions/ServiceCollectionExtensions.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Bot.Builder.Runtime.Extensions
         /// </summary>
         /// <param name="services">The application's collection of registered services.</param>
         /// <param name="configuration">The application configuration.</param>
-        public static void AddBotCore(this IServiceCollection services, IConfiguration configuration)
+        public static void AddBotRuntime(this IServiceCollection services, IConfiguration configuration)
         {
             if (services == null)
             {
@@ -47,7 +47,7 @@ namespace Microsoft.Bot.Builder.Runtime.Extensions
 
             string applicationRoot = configuration.GetSection(ConfigurationConstants.ApplicationRootKey).Value;
 
-            services.AddBotCore(
+            services.AddBotRuntime(
                 configuration,
                 resourceExplorerImplementationFactory: (serviceProvider) =>
                     new ResourceExplorer()
@@ -72,7 +72,7 @@ namespace Microsoft.Bot.Builder.Runtime.Extensions
         /// <param name="resourceExplorerImplementationFactory">
         /// Function used to build an instance of <see cref="ResourceExplorer"/> from registered services.
         /// </param>
-        internal static void AddBotCore(
+        internal static void AddBotRuntime(
             this IServiceCollection services,
             IConfiguration configuration,
             Func<IServiceProvider, ResourceExplorer> resourceExplorerImplementationFactory)

--- a/tests/Microsoft.Bot.Builder.Runtime.Tests/Extensions/ServiceCollectionExtensionTests.cs
+++ b/tests/Microsoft.Bot.Builder.Runtime.Tests/Extensions/ServiceCollectionExtensionTests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Bot.Builder.Runtime.Tests.Extensions
     {
         private const string ResourceId = "runtime.json";
 
-        public static IEnumerable<object[]> GetAddBotCoreThrowsArgumentNullExceptionData()
+        public static IEnumerable<object[]> GetAddBotRuntimeThrowsArgumentNullExceptionData()
         {
             IServiceCollection services = new ServiceCollection();
             IConfiguration configuration = TestDataGenerator.BuildConfigurationRoot();
@@ -54,12 +54,12 @@ namespace Microsoft.Bot.Builder.Runtime.Tests.Extensions
         }
 
         [Fact]
-        public void AddBotCore_Succeeds()
+        public void AddBotRuntime_Succeeds()
         {
             IServiceCollection services = new ServiceCollection();
             IConfiguration configuration = TestDataGenerator.BuildConfigurationRoot();
 
-            services.AddBotCore(
+            services.AddBotRuntime(
                 configuration,
                 (serviceProvider) => TestDataGenerator.BuildMemoryResourceExplorer(new[]
                 {
@@ -74,8 +74,8 @@ namespace Microsoft.Bot.Builder.Runtime.Tests.Extensions
         }
 
         [Theory]
-        [MemberData(nameof(GetAddBotCoreThrowsArgumentNullExceptionData))]
-        public void AddBotCore_Throws_ArgumentNullException(
+        [MemberData(nameof(GetAddBotRuntimeThrowsArgumentNullExceptionData))]
+        public void AddBotRuntime_Throws_ArgumentNullException(
             string paramName,
             IServiceCollection services,
             IConfiguration configuration,
@@ -83,17 +83,17 @@ namespace Microsoft.Bot.Builder.Runtime.Tests.Extensions
         {
             Assert.Throws<ArgumentNullException>(
                 paramName,
-                () => services.AddBotCore(configuration, resourceExplorerImplementationFactory));
+                () => services.AddBotRuntime(configuration, resourceExplorerImplementationFactory));
         }
 
         [Fact]
-        public void AddBotCore_Throws_RuntimeConfigurationNotFound()
+        public void AddBotRuntime_Throws_RuntimeConfigurationNotFound()
         {
             IServiceCollection services = new ServiceCollection();
             IConfiguration configuration = TestDataGenerator.BuildConfigurationRoot();
 
             ArgumentException exception = Assert.Throws<ArgumentException>(
-                () => services.AddBotCore(
+                () => services.AddBotRuntime(
                     configuration,
                     (serviceProvider) => TestDataGenerator.BuildMemoryResourceExplorer()));
 


### PR DESCRIPTION
Fixes #53 

Also renamed ConfigurationBuilderExtensions.AddBotCoreConfiguration to AddBotRuntimeConfiguration.